### PR TITLE
Implement core utilities and stub release tooling

### DIFF
--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# Colour output helpers
+_colour() {
+  local code=$1
+  shift
+  printf '\033[%sm%s\033[0m' "$code" "$*"
+}
+
+colour_red() { _colour 31 "$@"; }
+colour_green() { _colour 32 "$@"; }
+colour_yellow() { _colour 33 "$@"; }
+
+# Logging
+log() {
+  local emoji=$1
+  shift
+  printf '%b %s\n' "$emoji" "$*"
+}
+
+# Error handler
+_die() {
+  log "❌" "$*" >&2
+  exit 1
+}
+
+die() {
+  _die "$@"
+}
+
+# Ensure required commands exist
+require_cmd() {
+  local missing=0
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      log "⚠️" "Missing required command: $cmd"
+      missing=1
+    fi
+  done
+  [[ $missing -eq 0 ]] || _die "Required command not found"
+}
+
+# JSON helper using jq
+json_get() {
+  require_cmd jq
+  local json=$1
+  local filter=$2
+  echo "$json" | jq -r "$filter"
+}

--- a/scripts/lib/docker_ops.sh
+++ b/scripts/lib/docker_ops.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# shellcheck source=core.sh
+source "$(dirname "${BASH_SOURCE[0]}")/core.sh"
+
+ensure_network() {
+  log "🌐" "Ensuring network ${NETWORK_NAME:-unset}"
+}
+
+dk_run() {
+  log "🐳" "Starting ${CONTAINER_NAME:-container} with image ${IMAGE:-image}"
+}
+
+dk_stop() {
+  log "🛑" "Stopping ${CONTAINER_NAME:-container}"
+}
+
+probe_http() {
+  require_cmd curl
+  local url=$1
+  curl --silent --fail --max-time 2 "$url" >/dev/null
+}

--- a/scripts/lib/release_ops.sh
+++ b/scripts/lib/release_ops.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# shellcheck source=core.sh
+source "$(dirname "${BASH_SOURCE[0]}")/core.sh"
+# shellcheck source=docker_ops.sh
+source "$(dirname "${BASH_SOURCE[0]}")/docker_ops.sh"
+
+rc_build_local() {
+  require_cmd unzip
+  local intake_dir="${INTAKE_DIR:-/mnt/pipeline-intake}"
+  local artefact
+  artefact=$(ls "$intake_dir"/*.zip 2>/dev/null | head -n1 || true)
+  [[ -f "$artefact" ]] || die "No artefact found in $intake_dir"
+
+  rm -rf "$ROOT_DIR/runtime"
+  mkdir -p "$ROOT_DIR/runtime"
+  unzip -q "$artefact" -d "$ROOT_DIR/runtime"
+
+  ensure_network
+  dk_stop
+  dk_run
+
+  log "✅" "Local build complete"
+}

--- a/scripts/safe-rp-ctl
+++ b/scripts/safe-rp-ctl
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export ROOT_DIR
+
+# shellcheck source=lib/core.sh
+source "$SCRIPT_DIR/lib/core.sh"
+# shellcheck source=lib/docker_ops.sh
+source "$SCRIPT_DIR/lib/docker_ops.sh"
+# shellcheck source=lib/release_ops.sh
+source "$SCRIPT_DIR/lib/release_ops.sh"
+
+cmd="${1:-}"
+case "$cmd" in
+  build-local)
+    rc_build_local
+    ;;
+  *)
+    log "❌" "Unknown command: $cmd"
+    exit 1
+    ;;
+esac

--- a/tests/core.bats
+++ b/tests/core.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+@test "log prints emoji and message" {
+  run bash -c 'source scripts/lib/core.sh; log "ℹ️" "hello"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "ℹ️ hello" ]
+}
+
+@test "die exits with message" {
+  run bash -c 'source scripts/lib/core.sh; die "fail"'
+  [ "$status" -eq 1 ]
+  [ "$output" = "❌ fail" ]
+}
+
+@test "require_cmd fails on missing command" {
+  run bash -c 'source scripts/lib/core.sh; require_cmd some_missing_cmd'
+  [ "$status" -ne 0 ]
+}
+
+@test "json_get extracts value" {
+  run bash -c 'source scripts/lib/core.sh; echo "{\"a\":1}" | json_get .a'
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}


### PR DESCRIPTION
## Summary
- add `core.sh` with logging, error handling, command checks, colour helpers, and JSON parsing
- stub `docker_ops.sh` and `safe-rp-ctl` CLI
- implement `rc_build_local` and add basic BATS tests

## Testing
- `./scripts/safe-rp-ctl build-local`
- `shellcheck -e SC2034,SC2155 scripts/safe-rp-ctl scripts/lib/*.sh` *(fails: shellcheck: command not found)*
- `bats tests/core.bats` *(fails: bats: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d9e12d534832b9e95a4603f373d42