### PR TITLE
feat: add core utilities and docker ops scaffold

### DIFF
--- a/scripts/lib/docker_ops.sh
+++ b/scripts/lib/docker_ops.sh
@@ -5,16 +5,19 @@ IFS=$'\n\t'
 # shellcheck source=core.sh
 source "$(dirname "${BASH_SOURCE[0]}")/core.sh"
 
-ensure_network() {
-  log "🌐" "Ensuring network ${NETWORK_NAME:-unset}"
-}
-
 dk_run() {
-  log "🐳" "Starting ${CONTAINER_NAME:-container} with image ${IMAGE:-image}"
+  require_cmd docker
+  log_info "Starting ${CONTAINER_NAME:-container} with image ${IMAGE:-image}"
 }
 
 dk_stop() {
-  log "🛑" "Stopping ${CONTAINER_NAME:-container}"
+  require_cmd docker
+  log_info "Stopping ${CONTAINER_NAME:-container}"
+}
+
+ensure_network() {
+  require_cmd docker
+  log_info "Ensuring network ${NETWORK_NAME:-unset}"
 }
 
 probe_http() {

--- a/tests/core.bats
+++ b/tests/core.bats
@@ -1,15 +1,15 @@
 #!/usr/bin/env bats
 
-@test "log prints emoji and message" {
-  run bash -c 'source scripts/lib/core.sh; log "ℹ️" "hello"'
+@test "log_info prints icon and message" {
+  run bash -c 'source scripts/lib/core.sh; log_info "hello"'
   [ "$status" -eq 0 ]
-  [ "$output" = "ℹ️ hello" ]
+  [ "$output" = "ℹ️  hello" ]
 }
 
 @test "die exits with message" {
   run bash -c 'source scripts/lib/core.sh; die "fail"'
   [ "$status" -eq 1 ]
-  [ "$output" = "❌ fail" ]
+  [ "$output" = "✖ fail" ]
 }
 
 @test "require_cmd fails on missing command" {
@@ -18,7 +18,7 @@
 }
 
 @test "json_get extracts value" {
-  run bash -c 'source scripts/lib/core.sh; echo "{\"a\":1}" | json_get .a'
+  run bash -c 'source scripts/lib/core.sh; json_get "{\"a\":1}" .a'
   [ "$status" -eq 0 ]
   [ "$output" = "1" ]
 }


### PR DESCRIPTION
## Summary
- add POSIX-friendly core helper library with logging, dependency checks, JSON parsing and timestamp helper
- scaffold Docker helpers relying on core library functions
- adjust tests to cover new core helpers

## Testing
- `shellcheck scripts/lib/core.sh scripts/lib/docker_ops.sh` *(command not found: shellcheck)*
- `apt-get update` *(403 errors fetching packages)*
- `apt-get install -y shellcheck` *(package not found due to apt issues)*
- `bats tests` *(command not found: bats)*

------
https://chatgpt.com/codex/tasks/task_e_688da0e29104832bb405b22d9d5dc4fe