### PR TITLE
Make log helpers robust against pipe failures

### DIFF
--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -21,14 +21,21 @@ fi
 
 # Logging helpers -------------------------------------------------------
 _log() {
-  local icon=$1; shift
-  printf '%b%s%b %s\n' "${_col_grn}" "${icon}" "${_col_reset}" "$*"
+  local icon="$1"; shift
+  printf '%b%s%b %s\n' "${_col_grn}" "${icon}" "${_col_reset}" "$*" || true
+  return 0
 }
 
 log_info()    { _log "ℹ️ " "$*"; }
 log_success() { _log "✅" "$*"; }
-log_warn()    { printf '%b⚠️  %s%b\n'  "${_col_yel}" "$*" "${_col_reset}"; }
-log_error()   { printf '%b✖ %s%b\n' "${_col_red}" "$*" "${_col_reset}"; }
+log_warn() {
+  printf '%b⚠️  %s%b\n'  "${_col_yel}" "$*" "${_col_reset}" || true
+  return 0
+}
+log_error() {
+  printf '%b✖ %s%b\n' "${_col_red}" "$*" "${_col_reset}" || true
+  return 0
+}
 
 die() {
   log_error "$*" >&2

--- a/tests/core.bats
+++ b/tests/core.bats
@@ -6,6 +6,11 @@
   [ "$output" = "ℹ️  hello" ]
 }
 
+@test "_log ignores broken pipe and returns 0" {
+  run bash -c 'source scripts/lib/core.sh; _log "ℹ️ " "hello" | head -n0'
+  [ "$status" -eq 0 ]
+}
+
 @test "die exits with message" {
   run bash -c 'source scripts/lib/core.sh; die "fail"'
   [ "$status" -eq 1 ]


### PR DESCRIPTION
## Summary
- Ensure internal logging function always exits successfully and quotes icon parameter
- Guard warnings and errors against pipe failures for consistent return codes
- Add regression test for log helper with closed pipe

## Testing
- `bats tests` *(fails: command not found)*
- `apt-get install -y bats` *(fails: Unable to locate package due to 403)*
- `npm install -g bats` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688da6da9348832b8770295c400121f8