### PR TITLE
Add release manifest and inspection commands

### DIFF
--- a/scripts/lib/manifest_ops.sh
+++ b/scripts/lib/manifest_ops.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------
+# manifest_ops.sh – helpers for release manifest handling
+#-------------------------------------------------------------
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=core.sh
+source "$SCRIPT_DIR/core.sh"
+
+# manifest_write <release_id> <note> <apps_json>
+# Writes runtime/release.json with metadata and app list
+manifest_write() {
+  local id="$1"; shift
+  local note="$1"; shift
+  local apps_json="$1"
+  require_cmd jq
+  local built_at
+  built_at="$(date -u +%FT%TZ)"
+  local built_by
+  built_by="$(whoami)@$(hostname)"
+  jq -n --arg id "$id" \
+        --arg built_at "$built_at" \
+        --arg built_by "$built_by" \
+        --arg note "$note" \
+        --argjson apps "$apps_json" \
+        '{id:$id,built_at_utc:$built_at,built_by:$built_by,note:$note,apps:$apps}' \
+        > "$RUNTIME_DIR/release.json"
+}
+
+# manifest_pretty <path>
+manifest_pretty() {
+  local file="$1"
+  require_cmd jq
+  jq . "$file"
+}
+

--- a/scripts/safe-rp-ctl
+++ b/scripts/safe-rp-ctl
@@ -28,6 +28,12 @@ case "$cmd" in
   rollback)
     rc_rollback "$@"
     ;;
+  list-releases)
+    rc_list_releases
+    ;;
+  describe-release)
+    rc_describe_release "$@"
+    ;;
   *)
     log_error "Unknown command: $cmd"
     exit 1


### PR DESCRIPTION
## Summary
- generate release.json manifest with build metadata and app checksums
- expose list-releases/describe-release via safe-rp-ctl

## Testing
- `shellcheck scripts/lib/manifest_ops.sh scripts/lib/release_ops.sh scripts/safe-rp-ctl` *(failed: command not found)*
- `bats tests/core.bats` *(failed: command not found)*
- `./scripts/safe-rp-ctl list-releases` *(failed: Required command 'docker' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688db42ef390832ba9ded68715488401