### PR TITLE
Wire clone-prod command and guard color init

### DIFF
--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -10,11 +10,11 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Detect TTY for colours ------------------------------------------------
-if [[ -t 2 ]]; then
-  _col_reset="$(tput sgr0)"  || true
-  _col_red="$(tput setaf 1)"  || true
-  _col_yel="$(tput setaf 3)"  || true
-  _col_grn="$(tput setaf 2)"  || true
+if [[ -t 2 ]] && command -v tput >/dev/null 2>&1; then
+  _col_reset="$(tput sgr0 2>/dev/null || true)"
+  _col_red="$(tput setaf 1 2>/dev/null || true)"
+  _col_yel="$(tput setaf 3 2>/dev/null || true)"
+  _col_grn="$(tput setaf 2 2>/dev/null || true)"
 else
   _col_reset=""; _col_red=""; _col_yel=""; _col_grn="";
 fi

--- a/scripts/safe-rp-ctl
+++ b/scripts/safe-rp-ctl
@@ -17,7 +17,7 @@ cmd="${1:-}"
 shift || true
 case "$cmd" in
   build-local)
-    rc_build_local
+    rc_build_local "$@"
     ;;
   start)
     rc_start "$@"
@@ -33,6 +33,9 @@ case "$cmd" in
     ;;
   describe-release)
     rc_describe_release "$@"
+    ;;
+  clone-prod)
+    rc_clone_prod "$@"
     ;;
   *)
     log_error "Unknown command: $cmd"


### PR DESCRIPTION
## Summary
- add clone-prod case to safe-rp-ctl dispatcher and forward args to build-local
- guard colour initialization when `tput` is missing

## Testing
- `bats tests/core.bats` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm install -g bats` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688db9130394832b817872fe2b3faf39